### PR TITLE
Fix for scrum details blocker text

### DIFF
--- a/Microsoft.Teams.Apps.Scrum/Cards/ScrumCards.cs
+++ b/Microsoft.Teams.Apps.Scrum/Cards/ScrumCards.cs
@@ -253,7 +253,7 @@ namespace Microsoft.Teams.Apps.Scrum.Cards
                                },
                                new AdaptiveTextBlock
                                {
-                                   Text = scrumDetails.Today,
+                                   Text = scrumDetails.Blockers,
                                    Wrap = true,
                                    Weight = AdaptiveTextWeight.Lighter,
                                },


### PR DESCRIPTION
[Issue] - Scrum details card is using today text for blocker
[Fix] - Modified scrumcard file to use blockers string instead of today